### PR TITLE
Do not attempt to match newline characters

### DIFF
--- a/grammars/atom-syntax.cson
+++ b/grammars/atom-syntax.cson
@@ -2,7 +2,7 @@
 'scopeName':  'source.gentoo'
 'patterns': [
   {
-    'match': '#.*\\n'
+    'match': '#.*$'
     'name': 'comment'
   },
   {

--- a/grammars/ebuild.cson
+++ b/grammars/ebuild.cson
@@ -68,7 +68,7 @@
     'patterns' : [
       {
         'begin': '\\b(EAPI|DESCRIPTION|HOMEPAGE|SRC_URI|LICENSE|SLOT|KEYWORDS|IUSE|REQUIRED_USE|RESTRICT|(R|P)?DEPEND|S|PROPERTIES|DOCS)='
-        'end': '\\n'
+        'end': '$'
         'captures':
           '1':
             'name': 'support.constant.core.ebuild'
@@ -83,7 +83,7 @@
     'patterns' : [
       {
         'begin': '\\b(QA_.*)='
-        'end': '\\n'
+        'end': '$'
         'captures':
           '1':
             'name': 'support.constant.qa.ebuild'
@@ -98,7 +98,7 @@
     'patterns' : [
       {
         'begin': '\\b(ECVS_(SERVER|MODULE|BRANCH|AUTH|USER|PASS|TOPDIR|CVS_OPTIONS))='
-        'end': '\\n'
+        'end': '$'
         'captures':
           '1':
             'name': 'support.constant.cvs.ebuild'
@@ -113,7 +113,7 @@
     'patterns' : [
       {
         'begin': '\\b(ESVN_(REPO_URI|STORE_DIR|PROJECT|BOOTSTRAP|PATCHES))='
-        'end': '\\n'
+        'end': '$'
         'captures':
           '1':
             'name': 'support.constant.svn.ebuild'
@@ -128,7 +128,7 @@
     'patterns' : [
       {
         'begin': '\\b(EGIT_(USE_GIT_R3|(SOURCE|STORE)_DIR|HAS_SUBMODULES|OPTIONS|MASTER|PROJECT|DIR|REPO_URI|BRANCH|COMMIT|REPACK|PRUNE|NONBARE|NOUNPACK))='
-        'end': '\\n'
+        'end': '$'
         'captures':
           '1':
             'name': 'support.constant.git.ebuild'
@@ -143,7 +143,7 @@
     'patterns' : [
       {
         'begin': '\\b(EPATCH_(SOURCE|SUFFIX|OPTS|EXCLUDE|FORCE))='
-        'end': '\\n'
+        'end': '$'
         'captures':
           '1':
             'name': 'support.constant.epatch.ebuild'
@@ -158,7 +158,7 @@
     'patterns' : [
       {
         'begin': '\\b(inherit)\\b'
-        'end': '\\n'
+        'end': '$'
         'beginCaptures':
           '0' :
             'name': 'storage.modifier.shell'


### PR DESCRIPTION
This PR replaces all \n end matches with $. The two are nearly identical, with the only difference being that $ does not create a zero-width match at the end of the line. These changes are mainly required due to atom/first-mate#100, as newlines are no longer added to the last line of the file. Therefore, this change is simply a backwards-compatible change to ensure that language-gentoo continues working as before on Atom 1.22+.

/cc @Ingramz

Refs atom/atom#15729